### PR TITLE
Analysis of draft codelist for proms for anxiety and depression

### DIFF
--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -297,7 +297,56 @@ fig_proms_scores_trends
 
 ```
 
-
+#Table 1. Top 10 codes of PROMs for anxiety disorders and depression in adults from 2011/12 to 2023/24
 ```{r}
+#| label: tab-top-10-code
+#| message: false
+#| warning: false
+
+top_10_proms <- proms_usage |>
+  get_semantic_tag() |>
+  add_proms_match(search_patterns) |>
+  group_by(proms) |>
+  summarise(total_usage = sum(usage), .groups = "drop") |>
+  slice_max(total_usage, n = 10, with_ties = FALSE)
+ 
+top_10_proms_codes <- proms_usage |>
+  group_by(snomed_code, description) |>
+  summarise(total_usage = sum(usage), .groups = "drop") |>
+  slice_max(total_usage, n = 10, with_ties = FALSE)
+
+tab_top_10_proms_codes <- top_10_proms_codes |>
+    gt() |>
+  tab_header(
+    title = "Top 10 codes of PROMs for anxiety disorders and depression in adults",
+      subtitle = "from 2011/12 to 2023/24"
+  ) |>
+    tab_style(
+      style = list(
+        cell_text(font = "Courier New")
+      ),
+      locations = cells_body(columns = snomed_code)
+    ) |>
+    cols_label(
+      snomed_code = "SNOMED code",
+      description = "Description",
+      total_usage = "Total Usage"
+    ) |>
+    tab_style(
+      style = cell_text(weight = "bold"),
+      locations = cells_column_labels(columns = everything())
+    ) |>
+    cols_align(
+      align = "left",
+      columns = snomed_code
+    ) |>
+    tab_options(table.width = "100%") |>
+    tab_source_note(
+      source_note = md(
+        "Data source: NHS England SNOMED Usage in Primary Care."
+      )
+    )
+
+tab_top_10_proms_codes
 
 ```

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -1,0 +1,26 @@
+---
+title: "Analysis of draft codelist for PROMs for anxiety and depression"
+format: html
+editor: visual
+---
+
+## Quarto
+
+Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.
+
+## Running Code
+
+When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:
+
+```{r}
+1 + 1
+```
+
+You can add options to executable code like this
+
+```{r}
+#| echo: false
+2 * 2
+```
+
+The `echo: false` option disables the printing of code (only output is displayed).

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -194,7 +194,7 @@ proms_gen_table
 #Figure 1. Yearly trends in total code usage for all PROMs related to anxiety disorders and depression in adults from 2011/12 to 2023/24
 ```{r}
 #| label: fig-all-proms
-#| fig-cap: "Yearly counts of total usage broken down by PROMs and semantic tag from 2011/12 to 2023/24."
+#| fig-cap: "Figure 1. Yearly trends in total code usage for all PROMs related to anxiety disorders and depression in adults from 2011/12 to 2023/24."
 #| fig-height: 8
 #| fig-width: 8
 #| warning: false
@@ -244,3 +244,60 @@ fig_all_proms_total_usage
 
 ```
 
+#Figure 2. Yearly trends in codes for PROM scores for anxiety disorders and depression in adults by questionnaire from 2011/12 to 2023/24
+
+```{r}
+#| label: fig-proms-scores
+#| fig-cap: "Figure 2. Yearly trends in codes for PROM scores for anxiety disorders and depression in adults by questionnaire from 2011/12 to 2023/24"
+#| fig-height: 8
+#| fig-width: 14
+#| warning: false
+
+proms_scores <- proms_ob_en |>
+  add_proms_match(search_patterns)
+
+df_proms_scores <- proms_scores |> 
+  group_by(proms, end_date) |> 
+  mutate(total_usage = sum(usage)) |> 
+  select(end_date, total_usage, proms) |> 
+  ungroup() |> 
+  distinct()
+  
+fig_proms_scores_trends <- df_proms_scores |>
+  ggplot(
+      aes(
+        y = total_usage,
+        x = end_date,
+        colour = proms,
+      )
+    ) +
+    geom_line(alpha = 0.2) +
+    geom_point() +
+    labs(
+      x = NULL,
+      y = NULL,
+      colour = NULL,
+      caption = NULL,
+      title = NULL
+    ) +
+    scale_x_date(
+      date_breaks = "1 year",
+      labels = label_date_short()
+    ) +
+    scale_y_continuous(
+      labels = label_number(accuracy = 1),
+      limits = c(0, NA)
+    ) +
+    theme_bw() +
+    theme(legend.position = "bottom")
+  
+  
+fig_proms_scores_trends
+
+
+```
+
+
+```{r}
+
+```

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -189,3 +189,58 @@ proms_gen_table
 
 ```
 
+#Visualisations
+
+#Figure 1. Yearly trends in total code usage for all PROMs related to anxiety disorders and depression in adults from 2011/12 to 2023/24
+```{r}
+#| label: fig-all-proms
+#| fig-cap: "Yearly counts of total usage broken down by PROMs and semantic tag from 2011/12 to 2023/24."
+#| fig-height: 8
+#| fig-width: 8
+#| warning: false
+
+search_patterns <- map(search_terms, ~ str_c(.x, collapse = "|"))
+
+all_proms <- proms_usage |>
+  get_semantic_tag() |>
+  add_proms_match(search_patterns) 
+
+df_all_proms_total_usage <- all_proms |> 
+  group_by(proms, end_date) |> 
+  mutate(total_usage = sum(usage)) |> 
+  select(end_date, total_usage, proms) |> 
+  ungroup() |> 
+  distinct()
+
+fig_all_proms_total_usage <- df_all_proms_total_usage |> 
+  ggplot(
+      aes(
+        y = total_usage,
+        x = end_date,
+        colour = proms,
+      )
+    ) +
+    geom_line(alpha = 0.2) +
+    geom_point() +
+    labs(
+      x = NULL,
+      y = NULL,
+      colour = NULL,
+      caption = NULL,
+      title = "Count of code usage by PROMs"
+    ) +
+    scale_x_date(
+      date_breaks = "1 year",
+      labels = label_date_short()
+    ) +
+    scale_y_continuous(
+      labels = label_number(accuracy = 1),
+      limits = c(0, NA)
+    ) +
+    theme_bw() +
+    theme(legend.position = "bottom")
+
+fig_all_proms_total_usage
+
+```
+

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -203,7 +203,9 @@ search_patterns <- map(search_terms, ~ str_c(.x, collapse = "|"))
 
 all_proms <- proms_usage |>
   get_semantic_tag() |>
-  add_proms_match(search_patterns) 
+  add_proms_match(search_patterns) |>
+  mutate(proms = str_replace(proms, "epds;dep_screening", "epds")) |>
+  mutate(proms = str_replace(proms, "phq;dep_screening", "phq"))
 
 df_all_proms_total_usage <- all_proms |> 
   group_by(proms, end_date) |> 
@@ -254,7 +256,9 @@ fig_all_proms_total_usage
 #| warning: false
 
 proms_scores <- proms_ob_en |>
-  add_proms_match(search_patterns)
+  add_proms_match(search_patterns) |>
+  mutate(proms = str_replace(proms, "epds;dep_screening", "epds")) |>
+  mutate(proms = str_replace(proms, "phq;dep_screening", "phq"))
 
 df_proms_scores <- proms_scores |> 
   group_by(proms, end_date) |> 

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -153,4 +153,20 @@ tab_proms_procedure
 
 ```
 
+```{r}
+#| label: tab-proms-gen
+#| message: false
+#| warning: false
 
+proms_gen_table <- proms_usage |>
+  filter(snomed_code %in% proms_gen$snomed_code) |>
+  get_semantic_tag() |>
+  summarise_code_counts() |>
+  create_table_sem_tag(
+    title = "Summary of Generic PROMs SNOMED code usage",
+    subtitle = "Timeframe: August 2011 to July 2024"
+  )
+  
+proms_gen_table
+
+```

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -1,26 +1,130 @@
 ---
 title: "Analysis of draft codelist for PROMs for anxiety and depression"
-format: html
-editor: visual
+toc: true
+toc-depth: 2
+format:
+  html:
+    code-fold: true
+    code-summary: "Show the code"
+    other-links:
+      - text: opencodecounts R pkg
+        href: https://bennettoxford.github.io/opencodecounts/
+      - text: SNOMED Code Usage
+        href: https://digital.nhs.uk/data-and-information/publications/statistical/mi-snomed-code-usage-in-primary-care
+editor: source
 ---
 
-## Quarto
+# Overview
 
-Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.
+# Methods
 
-## Running Code
-
-When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:
+# Analysis
 
 ```{r}
-1 + 1
+#| label: setup
+#| message: false
+#| results: 'hide'
+#| warning: false
+#| echo: true
+
+library(opencodecounts)
+library(tidyverse)
+library(gt)
+library(scales)
+library(here)
+library(patchwork)
+
+source(here("lib", "fun_tables.R"))
+source(here("lib", "fun_data.R"))
+source(here("lib", "fun_figures.R"))
+
+search_terms <- list(
+  phq = c("Patient Health Questionnaire"),
+  bai = c("Beck Anxiety"),
+  bdi = c("Beck Depression"),
+  gad = c("Generalized Anxiety Disorder", "Generalised anxiety disorder"),
+  whooley = c("Whooley"),
+  mi = c("Mobility Inventory"),
+  spin = c("Social Phobia Inventory"),
+  cfq = c("Chalder Fatigue"),
+  oci = c("Obsessive Compulsive Inventory"),
+  ibssss = c("Irritable Bowel Syndrome - Symptom Severity Scale"),
+  epds = c("Postpartum Depression Screening"),
+  hdrs = c("Hamilton rating scale"),
+  hads = c("Hospital Anxiety and Depression Scale"),
+  gds = c("Geriatric depression scale"),
+  anx_screening = c("anxiety screening", "anxiety scale"),
+  dep_screening = c("depression screening")
+)
+
+#general/generic proms
+general_proms <- c("anxiety screening","depression screening")
+
+proms_gen <- snomed_usage |>
+  filter_terms(general_proms) |>
+  filter(!grepl("Patient Health Questionnaire|Postpartum", description, ignore.case = TRUE))
+
+search_patterns <- map(search_terms, ~ str_c(.x, collapse = "|"))
+
+#retrieve proms codelist for anxiety and depression
+proms_cod <- get_codelist("user/Lola_O/patient-reported-outcome-measures-anxiety-and-depression/615e2d89/")
+
+#filter snomed usage by codelist
+proms_usage <- snomed_usage |>
+  filter(snomed_code %in% proms_cod$code)
+
+
+
 ```
 
-You can add options to executable code like this
+## Categorisation of PROMs codelist
+```{r}
+#| label: tab-proms-ob-en
+#| message: false
+#| warning: false
+#Observable entities for specific PROMs
+
+#only codes with observable entity tags
+proms_ob_en <- proms_usage |>
+  get_semantic_tag() |>                                  # Extract semantic tag and add new variable
+  filter_terms("observable entity") |>                   # filter only observable entities
+  filter(!snomed_code %in% proms_gen$snomed_code)        # filter out generic proms
+  
+# Calculate total code usage for entire period
+proms_ob_en_count<- proms_ob_en |>     
+  summarise_code_counts()                                
+
+# Create table grouped by semantic_tag - 38 PROMs with observable entities
+tab_proms_ob_en_count <- proms_ob_en_count |>
+  create_table_sem_tag(
+    title = "Summary of All PROMs observable entity SNOMED codes usage",
+    subtitle = "Timeframe: August 2011 to July 2024"
+  )
+
+tab_proms_ob_en_count
+
+```
 
 ```{r}
-#| echo: false
-2 * 2
-```
+#| label: tab-proms-declined
+#| message: false
+#| warning: false
 
-The `echo: false` option disables the printing of code (only output is displayed).
+#only declined codes
+proms_declined <- proms_usage |>
+  get_semantic_tag() |>
+  filter_terms("declined") 
+
+tab_proms_declined <- proms_declined |>
+  summarise_code_counts() |>
+  create_table_sem_tag(
+    title = "Summary of All PROMs declined related SNOMED codes usage",
+    subtitle = "Timeframe: August 2011 to July 2024"
+  )
+
+
+tab_proms_declined
+
+
+
+```

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -49,12 +49,32 @@ search_terms <- list(
   cfq = c("Chalder Fatigue"),
   oci = c("Obsessive Compulsive Inventory"),
   ibssss = c("Irritable Bowel Syndrome - Symptom Severity Scale"),
-  epds = c("Postpartum Depression Screening"),
+  epds = c("Postpartum Depression Screening", "Edinburgh postnatal depression scale"),
   hdrs = c("Hamilton rating scale"),
   hads = c("Hospital Anxiety and Depression Scale"),
-  gds = c("Geriatric depression scale"),
-  anx_screening = c("anxiety screening", "anxiety scale"),
-  dep_screening = c("depression screening")
+  gds = c("Geriatric depression"),
+  anx_screening = c("anxiety screening"),
+  dep_screening = c("depression screening", "Depression follow-up"),
+  dep_cards = c("Depression Cards"),
+  dep_rating = c("Brief depression rating scale"),
+  leeds = c("leeds scales"),
+  mam = c("marks and mathews"),
+  wakefield = c("wakefield"),
+  zung = c("zung"),
+  who_dep = c("World Health Organization depression scale"),
+  montgomery = c("Montgomery"),
+  euroqol = c("euroqol"),
+  hai = c("health anxiety inventory"),
+  pdss = c("panic disorder severity scale"),
+  dep_self = c("depression self rating scale"),
+  ptsd = c("Post-traumatic stress disorder checklist"),
+  cvppd9 = c("Current View Provisional Problem Description item 9 score"),
+  dass = c("Depression anxiety stress scales"),
+  dapo = c("Depression, Anxiety and Positive Outlook Scale"),
+  biq = c("Body Image Questionnaire"),
+  dep_anx = c("Depression anxiety scale"),
+  dep_intensity = c("Depression intensity scale circles score")
+  
 )
 
 #general/generic proms
@@ -64,7 +84,6 @@ proms_gen <- snomed_usage |>
   filter_terms(general_proms) |>
   filter(!grepl("Patient Health Questionnaire|Postpartum", description, ignore.case = TRUE))
 
-search_patterns <- map(search_terms, ~ str_c(.x, collapse = "|"))
 
 #retrieve proms codelist for anxiety and depression
 proms_cod <- get_codelist("user/Lola_O/patient-reported-outcome-measures-anxiety-and-depression/615e2d89/")
@@ -72,7 +91,6 @@ proms_cod <- get_codelist("user/Lola_O/patient-reported-outcome-measures-anxiety
 #filter snomed usage by codelist
 proms_usage <- snomed_usage |>
   filter(snomed_code %in% proms_cod$code)
-
 
 
 ```
@@ -170,3 +188,4 @@ proms_gen_table <- proms_usage |>
 proms_gen_table
 
 ```
+

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -128,3 +128,29 @@ tab_proms_declined
 
 
 ```
+
+
+```{r}
+#| label: tab-proms-procedures
+#| message: false
+#| warning: false
+
+
+#only procedure codes for specific 
+proms_procedure <- proms_usage |>
+  get_semantic_tag() |>
+  filter_terms(c("procedure", "assessment scale")) |>
+  filter(!snomed_code %in% proms_gen$snomed_code)
+
+tab_proms_procedure <- proms_procedure |>
+  summarise_code_counts() |>
+  create_table_sem_tag(
+    title = "Summary of All PROMs procedure SNOMED codes usage",
+    subtitle = "Timeframe: August 2011 to July 2024"
+  )
+
+tab_proms_procedure
+
+```
+
+

--- a/analysis/anx_dep_proms_cod_analysis.qmd
+++ b/analysis/anx_dep_proms_cod_analysis.qmd
@@ -306,18 +306,13 @@ fig_proms_scores_trends
 #| label: tab-top-10-code
 #| message: false
 #| warning: false
-
-top_10_proms <- proms_usage |>
-  get_semantic_tag() |>
-  add_proms_match(search_patterns) |>
-  group_by(proms) |>
-  summarise(total_usage = sum(usage), .groups = "drop") |>
-  slice_max(total_usage, n = 10, with_ties = FALSE)
  
 top_10_proms_codes <- proms_usage |>
   group_by(snomed_code, description) |>
-  summarise(total_usage = sum(usage), .groups = "drop") |>
-  slice_max(total_usage, n = 10, with_ties = FALSE)
+  summarise(usage = sum(usage), .groups = "drop") |>
+  mutate(ratio_usage = usage / sum(usage)) |>
+  arrange(-usage) |>
+  slice_head(n = 10)
 
 tab_top_10_proms_codes <- top_10_proms_codes |>
     gt() |>
@@ -325,6 +320,10 @@ tab_top_10_proms_codes <- top_10_proms_codes |>
     title = "Top 10 codes of PROMs for anxiety disorders and depression in adults",
       subtitle = "from 2011/12 to 2023/24"
   ) |>
+  fmt_percent(
+      columns = c(ratio_usage),
+      decimals = 1
+    ) |>
     tab_style(
       style = list(
         cell_text(font = "Courier New")
@@ -334,7 +333,8 @@ tab_top_10_proms_codes <- top_10_proms_codes |>
     cols_label(
       snomed_code = "SNOMED code",
       description = "Description",
-      total_usage = "Total Usage"
+      usage = "Total Usage",
+      ratio_usage = "%"
     ) |>
     tab_style(
       style = cell_text(weight = "bold"),


### PR DESCRIPTION


- Extended the PROM search dictionary (esp. non-NICE/NHS-TT instruments) to ensure complete grouping.
- Collapsed EPDS variants (“postnatal”/“postpartum”) to a single EPDS label.
- Refined generic “anxiety/depression screening” patterns and explicitly excluded PHQ and EPDS from the generic bucket.
- Defined the procedures subset as semantic tags procedure and assessment scale.
- Added tables for each categorisation (observable entities, procedures/assessment scales, declined, generic).
- Added Figures 1 & 2 (all-PROMs monthly usage; observable-entity score trends).